### PR TITLE
 Address multiple compiler warnings and rename a few variants for clarity

### DIFF
--- a/IPS.gd
+++ b/IPS.gd
@@ -7,6 +7,6 @@ func _ready():
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
+func _process(_delta):
 	text = "IPS: " + str(Singleton.ips)
 	pass

--- a/InputBar.gd
+++ b/InputBar.gd
@@ -1,8 +1,8 @@
 extends Node
 
 var released = false
-var kb
-var btn
+var kb # unused (is never read)
+var kb_btn
 var gp_btn
 var gp_axis
 var gp_axis_device
@@ -18,14 +18,14 @@ func _ready():
 	rect = $ColorRect
 	rect.color = color
 	rect.color.a = 1
-	x += (50-Singleton.w)/2
+	x += floor((50-Singleton.width)/2.0)
 	rect.position.x = x
-	rect.size.x = Singleton.w
+	rect.size.x = Singleton.width
 	rect.position.y += y
 	
 func _input(ev):
 	if not released:
-		if ev is InputEventKey and ev.keycode == btn and not ev.pressed:
+		if ev is InputEventKey and ev.keycode == kb_btn and not ev.pressed:
 			bar_release()
 		if ev is InputEventJoypadButton and ev.button_index == gp_btn and not ev.pressed:
 			bar_release()

--- a/Singleton.gd
+++ b/Singleton.gd
@@ -3,9 +3,10 @@ extends Node
 var inputs_gone = []
 var ips = 0
 var scroll_rate = 400
-var w = 50
+var width = 50
 var colors = ["#00FF00","#FF0000","#FFFF00","#0000FF","#FF8000","#8000FF","#8000FF"]
 var config
+var config_version = 1.1
 var calibration
 var deadzone = 0.5
 
@@ -16,8 +17,10 @@ func _ready():
 	if err != OK:
 		print("error reading settings file; using default values...")
 		return
+
+	config_version = config.get_value("Meta", "config_version", 1) # assume config v1, because that config version doesn't have the "Meta" section.
 	scroll_rate = config.get_value("Settings", "scroll_rate")
-	w = config.get_value("Settings", "width")
+	width = config.get_value("Settings", "width")
 	colors[0] = config.get_value("Colors", "green")
 	colors[1] = config.get_value("Colors", "red")
 	colors[2] = config.get_value("Colors", "yellow")
@@ -53,12 +56,12 @@ func _input(ev):
 		match (ev.keycode):
 			45:	scroll_rate -= 10 # -
 			61:	scroll_rate += 10 # =
-			91:	w -= 1 # [
-			93:	w += 1 # ]
+			91:	width -= 1 # [
+			93:	width += 1 # ]
 			4194308: inputs_gone = []
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
+func _process(_delta):
 	# auto-calibration on app start; doesn't quite work in _ready()
 	if (calibration == null): calibrate()
 	
@@ -76,28 +79,29 @@ func _notification(what):
 	if what == NOTIFICATION_WM_CLOSE_REQUEST:
 		
 		# save settings here
-		var config = ConfigFile.new()
+		var new_config = ConfigFile.new()
 		# Store some values.
-		config.set_value("Settings", "scroll_rate", scroll_rate)
-		config.set_value("Settings", "width", w)
-		config.set_value("Colors", "green", colors[0])
-		config.set_value("Colors", "red", colors[1])
-		config.set_value("Colors", "yellow", colors[2])
-		config.set_value("Colors", "blue", colors[3])
-		config.set_value("Colors", "orange", colors[4])
-		config.set_value("Colors", "up", colors[5])
-		config.set_value("Colors", "down", colors[6])
+		new_config.set_value("Meta", "config_version", 1.1)
+		new_config.set_value("Settings", "scroll_rate", scroll_rate)
+		new_config.set_value("Settings", "width", width)
+		new_config.set_value("Colors", "green", colors[0])
+		new_config.set_value("Colors", "red", colors[1])
+		new_config.set_value("Colors", "yellow", colors[2])
+		new_config.set_value("Colors", "blue", colors[3])
+		new_config.set_value("Colors", "orange", colors[4])
+		new_config.set_value("Colors", "up", colors[5])
+		new_config.set_value("Colors", "down", colors[6])
 		# bindings
 		var names = ["G","R","Y","B","O","U","D"]
 		var i = 0
-		for name in names:
-			var node = get_node("/root/Node2D/" + name)
-			config.set_value(str(i), "btn", node.btn)
-			config.set_value(str(i), "gp_btn", node.gp_btn)
-			config.set_value(str(i), "gp_axis", node.gp_axis)
-			config.set_value(str(i), "gp_axis_device", node.gp_axis_device)
-			config.set_value(str(i), "gp_axis_positive", node.gp_axis_positive)
+		for node_name in names:
+			var node = get_node("/root/Node2D/" + node_name)
+			new_config.set_value(str(i), "kb_btn", node.kb_btn)
+			new_config.set_value(str(i), "gp_btn", node.gp_btn)
+			new_config.set_value(str(i), "gp_axis", node.gp_axis)
+			new_config.set_value(str(i), "gp_axis_device", node.gp_axis_device)
+			new_config.set_value(str(i), "gp_axis_positive", node.gp_axis_positive)
 			i += 1
 		# Save it to a file (overwrite if already exists).
-		config.save("user://yaid_settings.cfg")
+		new_config.save("user://yaid_settings.cfg")
 		get_tree().quit() # default behavior

--- a/fps.gd
+++ b/fps.gd
@@ -1,4 +1,4 @@
 extends Label
 
-func _process(delta):
+func _process(_delta):
 	set_text("FPS: " + str(Engine.get_frames_per_second()))

--- a/inputbtn.gd
+++ b/inputbtn.gd
@@ -1,7 +1,7 @@
 extends Area2D
 
 const inputbar = preload("res://input_bar.tscn")
-var btn
+var kb_btn
 var gp_btn
 var gp_axis
 var gp_axis_device
@@ -10,7 +10,7 @@ var label
 var center
 var color
 var count = 0
-var max_a = 0.5
+var max_alpha = 0.5
 var fade_rate = 4
 var spawn_inputbar = true
 var length_label
@@ -29,7 +29,10 @@ var gp_previous_framecount = 0.0
 func _ready():
 	index = get_meta("index")
 	# bindings
-	btn = Singleton.config.get_value(str(index), "btn", get_meta("btn"))
+	if Singleton.config_version == 1.1: # this has to be checked incase a config with an older version is read
+		kb_btn = Singleton.config.get_value(str(index), "kb_btn", get_meta("kb_btn"))
+	else:
+		kb_btn = Singleton.config.get_value(str(index), "btn", get_meta("kb_btn"))
 	gp_btn = Singleton.config.get_value(str(index), "gp_btn", get_meta("gp_btn"))
 	gp_axis = Singleton.config.get_value(str(index), "gp_axis", null)
 	gp_axis_device = Singleton.config.get_value(str(index), "gp_axis_device", null)
@@ -65,7 +68,7 @@ func _input(ev):
 		if mapping:
 			var result = Singleton.process_axis_input(ev.device,ev.axis,ev.axis_value)
 			if not pressed and result["pressed"]:
-				btn = null
+				kb_btn = null
 				gp_btn = null
 				gp_axis = ev.axis
 				gp_axis_device = ev.device
@@ -88,7 +91,7 @@ func _input(ev):
 		if mapping:
 			if ev.pressed:
 				gp_axis = null
-				btn = null
+				kb_btn = null
 				gp_btn = ev.button_index
 			else:
 				mapping = false
@@ -110,7 +113,7 @@ func _input(ev):
 			if ev.pressed:
 				gp_axis = null
 				gp_btn = null
-				btn = ev.keycode
+				kb_btn = ev.keycode
 			else:
 				mapping = false
 		else:
@@ -119,7 +122,7 @@ func _input(ev):
 				label.text = str(count)
 				length = 0
 				length_label.text = "%0.3f" % length
-			if ev.keycode == btn:
+			if ev.keycode == kb_btn:
 				if ev.pressed:
 					update_input_counter(true)
 				else:
@@ -135,7 +138,7 @@ func _process(delta):
 			length += delta
 			length_label.text = "%0.3f" % length
 	elif mapping:
-		center.color.a = max_a
+		center.color.a = max_alpha
 	else:
 		if center.color.a > color.a:
 			center.color.a -= fade_rate * delta
@@ -147,7 +150,7 @@ func update_input_counter(kb = true):
 	pressed = true
 	count = count + 1
 	label.text = str(count)
-	center.color.a = max_a
+	center.color.a = max_alpha
 	timestamp = Time.get_unix_time_from_system()
 	if spawn_inputbar:
 		# resize text dynamically
@@ -160,7 +163,7 @@ func update_input_counter(kb = true):
 		length = 0
 		var new_inputbar = inputbar.instantiate()
 		new_inputbar.kb = kb
-		new_inputbar.btn = btn
+		new_inputbar.kb_btn = kb_btn
 		new_inputbar.gp_btn = gp_btn
 		new_inputbar.gp_axis = gp_axis
 		new_inputbar.gp_axis_device = gp_axis_device

--- a/inputbtn.tscn
+++ b/inputbtn.tscn
@@ -15,7 +15,7 @@ font_size = 12
 
 [node name="Button" type="Area2D"]
 script = ExtResource("1_fkaf7")
-metadata/btn = 65
+metadata/kb_btn = 65
 metadata/color = Color(1, 1, 1, 1)
 metadata/inputbar = true
 metadata/index = 0

--- a/inputstrum.tscn
+++ b/inputstrum.tscn
@@ -10,7 +10,7 @@ font_size = 8
 
 [node name="Button" type="Area2D"]
 script = ExtResource("1_7v6oi")
-metadata/btn = 65
+metadata/kb_btn = 65
 metadata/color = Color(0.501961, 0, 1, 1)
 metadata/inputbar = false
 metadata/index = 5

--- a/main.tscn
+++ b/main.tscn
@@ -13,40 +13,40 @@ metadata/color = Color(0, 1, 0, 1)
 
 [node name="R" parent="." instance=ExtResource("1_7vupe")]
 position = Vector2(50, 50)
-metadata/btn = 83
+metadata/kb_btn = 83
 metadata/color = Color(1, 0, 0, 1)
 metadata/index = 1
 metadata/gp_btn = 1
 
 [node name="Y" parent="." instance=ExtResource("1_7vupe")]
 position = Vector2(100, 50)
-metadata/btn = 68
+metadata/kb_btn = 68
 metadata/color = Color(1, 1, 0, 1)
 metadata/index = 2
 metadata/gp_btn = 3
 
 [node name="B" parent="." instance=ExtResource("1_7vupe")]
 position = Vector2(150, 50)
-metadata/btn = 70
+metadata/kb_btn = 70
 metadata/color = Color(0, 0, 1, 1)
 metadata/index = 3
 metadata/gp_btn = 2
 
 [node name="O" parent="." instance=ExtResource("1_7vupe")]
 position = Vector2(200, 50)
-metadata/btn = 71
+metadata/kb_btn = 71
 metadata/color = Color(1, 0.501961, 0, 1)
 metadata/index = 4
 metadata/gp_btn = 9
 
 [node name="U" parent="." instance=ExtResource("2_m1xo0")]
 position = Vector2(0, 25)
-metadata/btn = 4194320
+metadata/kb_btn = 4194320
 metadata/gp_btn = 11
 
 [node name="D" parent="." instance=ExtResource("2_m1xo0")]
 position = Vector2(125, 25)
-metadata/btn = 4194322
+metadata/kb_btn = 4194322
 metadata/index = 6
 metadata/gp_btn = 12
 


### PR DESCRIPTION
Specifically, i renamed btn to kb_btn (in multiple files), Singleton.w to width and inputbtn.max_a to max_alpha.
This is mostly for readability and removing ambiguity.
The rename from btn to kb_btn is also applied to the config.

The addressed compiler warnings were mostly related to unused `delta` parameters in the `_process(delta)` methods of multiple scripts, which I renamed to `_delta`.
Additionally there was some variant shadowing in Singleton._notification(what).

One compiler warning was related to integer division being done in InputBar.gd, and the decimal place being discarded.
This is odd, as the width can very well be set to a decimal value in the config, which would also result in decimal value division. Nonetheless, i added a floor() statement around the variants to ensure that the decimal places will always be rounded down after the division. 

To differentiate between the old and new iteration of the config, i added a "Meta" section with a "config_version" parameter.
I decided the config version for the current config is 1, and the config version that uses this change is 1.1
I am currently doing a lot of config modifications on a separate branch to fix a variety of issues relating to it, that will use config_version 2 because it changes a lot more.

I tested this build a bit and got no errors (except the ones that i am gonna address among other things, with config v2) but i mainly tested if the config was being written and read correctly.

Yeah this one is a lil big but its also more than it seems, i just wanted to make everything clear.