### PR TITLE
Fix Program Freeze on Gamepad Connect + Correct Window Size Limits

### DIFF
--- a/Singleton.gd
+++ b/Singleton.gd
@@ -20,6 +20,10 @@ var deadzone = 0.5
 func _ready():
 	get_tree().set_auto_accept_quit(false)
 	DisplayServer.window_set_min_size(Vector2i(820, 64))
+	Input.joy_connection_changed.connect(_on_joy_connection_changed)
+
+func _on_joy_connection_changed(_device: int, _connected: bool):
+	calibrate()
 
 func calibrate():
 	calibration = {}

--- a/Singleton.gd
+++ b/Singleton.gd
@@ -19,7 +19,12 @@ var deadzone = 0.5
 	
 func _ready():
 	get_tree().set_auto_accept_quit(false)
-	DisplayServer.window_set_min_size(Vector2i(820, 64))
+	
+	# InputBtn width is 50, so just 50*5
+	# InputBtn height is 50, InputStrum height is 25,
+	# but InputStrum is positioned 25 pixels lower, which adds up to 100
+
+	DisplayServer.window_set_min_size(Vector2i(250, 100))
 	Input.joy_connection_changed.connect(_on_joy_connection_changed)
 
 func _on_joy_connection_changed(_device: int, _connected: bool):


### PR DESCRIPTION
Freeze on Gamepad connect:
`InputBtn`s would almost immediately receive a device's Axis inputs upon connect, but, because the device didn't exist during previous `Singleton.calibrate()` calls, this would result in a LOT of console errors relating to the input device's index not existing in `Singleton.calibration`, which would be accessed by `Singleton.process_axis_input()` calls of the `InputBtn`s. To counteract this, `Singleton.calibrate()` will be run if a new device is detected, which should update `Singleton.calibration` before any inputs can be received by `InputBtn`s.

Window size limits:
This one is a silly oversight of mine.
Originally, the Config UI was part of the main Window, instead of floating above in a seperate window. Because of this, the limit on Window size is way larger than it needs to be. It is now set to 250 (`InputBtn` width ×5). Also, the previous minimum height was 64 as anything lower causes issues with Godot. It is now set to 100, which makes the new minimum Window size neatly fit to the `InputBtn`s.