### PR TITLE
Just a Godot version bump to 4.4 (for the most part)

### DIFF
--- a/Binding.gd.uid
+++ b/Binding.gd.uid
@@ -1,0 +1,1 @@
+uid://ddfthu2mnn8i2

--- a/Config.gd.uid
+++ b/Config.gd.uid
@@ -1,0 +1,1 @@
+uid://dfyeayakov31h

--- a/ConfigHandler.gd.uid
+++ b/ConfigHandler.gd.uid
@@ -1,0 +1,1 @@
+uid://c8hrjfi6ocla5

--- a/ConfigInterface/ConfigInterface.gd.uid
+++ b/ConfigInterface/ConfigInterface.gd.uid
@@ -1,0 +1,1 @@
+uid://c1swk6oy25iny

--- a/ConfigInterface/ConfigInterface.tscn
+++ b/ConfigInterface/ConfigInterface.tscn
@@ -1,15 +1,16 @@
 [gd_scene load_steps=9 format=3 uid="uid://diwo8r877y02c"]
 
-[ext_resource type="Script" path="res://ConfigInterface/ConfigInterface.gd" id="1_gkws8"]
+[ext_resource type="Script" uid="uid://c1swk6oy25iny" path="res://ConfigInterface/ConfigInterface.gd" id="1_gkws8"]
 [ext_resource type="PackedScene" uid="uid://bcresji1hnjiu" path="res://ConfigInterface/FretColorPicker.tscn" id="1_l4cb1"]
 [ext_resource type="Texture2D" uid="uid://wmw6outrhpp5" path="res://ConfigInterface/blobnomcookie.png" id="1_yue4u"]
 [ext_resource type="PackedScene" uid="uid://bcjdywc38khs8" path="res://ConfigInterface/StrumColorPicker.tscn" id="3_5dgwu"]
-[ext_resource type="Script" path="res://ConfigInterface/IPSToggle.gd" id="3_bmsq3"]
-[ext_resource type="Script" path="res://ConfigInterface/ScrollSpeedSpinBox.gd" id="4_thkfi"]
-[ext_resource type="Script" path="res://ConfigInterface/HamburgerToggle.gd" id="5_fhkjl"]
-[ext_resource type="Script" path="res://ConfigInterface/InputbarWidthSpinBox.gd" id="5_wy8my"]
+[ext_resource type="Script" uid="uid://ddkoeidsjlmeu" path="res://ConfigInterface/IPSToggle.gd" id="3_bmsq3"]
+[ext_resource type="Script" uid="uid://dknf7icrvodmq" path="res://ConfigInterface/ScrollSpeedSpinBox.gd" id="4_thkfi"]
+[ext_resource type="Script" uid="uid://bwoqxkhxjbnwa" path="res://ConfigInterface/HamburgerToggle.gd" id="5_fhkjl"]
+[ext_resource type="Script" uid="uid://dbqb8oacyv82l" path="res://ConfigInterface/InputbarWidthSpinBox.gd" id="5_wy8my"]
 
 [node name="ConfigInterface" type="Window"]
+auto_translate_mode = 2
 title = "ya_inputdisplay - Configuration"
 initial_position = 2
 size = Vector2i(520, 125)
@@ -67,6 +68,7 @@ offset_bottom = 150.0
 color = Color(0, 0, 0, 1)
 
 [node name="ColorPanel" type="Panel" parent="MainBackground"]
+layout_mode = 0
 offset_right = 250.0
 offset_bottom = 75.0
 
@@ -185,6 +187,7 @@ grow_horizontal = 1
 grow_vertical = 1
 
 [node name="MiscPanel" type="Panel" parent="MainBackground"]
+layout_mode = 0
 offset_left = 250.0
 offset_right = 550.0
 offset_bottom = 75.0

--- a/ConfigInterface/FretColorPicker.gd.uid
+++ b/ConfigInterface/FretColorPicker.gd.uid
@@ -1,0 +1,1 @@
+uid://dkk7sc2tihhqi

--- a/ConfigInterface/FretColorPicker.tscn
+++ b/ConfigInterface/FretColorPicker.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3 uid="uid://bcresji1hnjiu"]
 
-[ext_resource type="Script" path="res://ConfigInterface/FretColorPicker.gd" id="1_lgb08"]
+[ext_resource type="Script" uid="uid://dkk7sc2tihhqi" path="res://ConfigInterface/FretColorPicker.gd" id="1_lgb08"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_83ida"]
 font_size = 35

--- a/ConfigInterface/HamburgerToggle.gd.uid
+++ b/ConfigInterface/HamburgerToggle.gd.uid
@@ -1,0 +1,1 @@
+uid://bwoqxkhxjbnwa

--- a/ConfigInterface/IPSToggle.gd.uid
+++ b/ConfigInterface/IPSToggle.gd.uid
@@ -1,0 +1,1 @@
+uid://ddkoeidsjlmeu

--- a/ConfigInterface/InputbarWidthSpinBox.gd.uid
+++ b/ConfigInterface/InputbarWidthSpinBox.gd.uid
@@ -1,0 +1,1 @@
+uid://dbqb8oacyv82l

--- a/ConfigInterface/ScrollSpeedSpinBox.gd.uid
+++ b/ConfigInterface/ScrollSpeedSpinBox.gd.uid
@@ -1,0 +1,1 @@
+uid://dknf7icrvodmq

--- a/ConfigInterface/StrumColorPicker.tscn
+++ b/ConfigInterface/StrumColorPicker.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3 uid="uid://bcjdywc38khs8"]
 
-[ext_resource type="Script" path="res://ConfigInterface/FretColorPicker.gd" id="1_wm0qo"]
+[ext_resource type="Script" uid="uid://dkk7sc2tihhqi" path="res://ConfigInterface/FretColorPicker.gd" id="1_wm0qo"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_83ida"]
 font_size = 14

--- a/FPS.gd.uid
+++ b/FPS.gd.uid
@@ -1,0 +1,1 @@
+uid://c1lvyeh0nqgcw

--- a/HideableUI.gd.uid
+++ b/HideableUI.gd.uid
@@ -1,0 +1,1 @@
+uid://djkjj2xp8gqn7

--- a/InputBar.gd.uid
+++ b/InputBar.gd.uid
@@ -1,0 +1,1 @@
+uid://ixea48sduubq

--- a/InputBar.tscn
+++ b/InputBar.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://psxbu02ctrml"]
 
-[ext_resource type="Script" path="res://InputBar.gd" id="1_wnqpl"]
+[ext_resource type="Script" uid="uid://ixea48sduubq" path="res://InputBar.gd" id="1_wnqpl"]
 
 [node name="InputBar" type="Node"]
 script = ExtResource("1_wnqpl")

--- a/InputBtn.gd
+++ b/InputBtn.gd
@@ -54,7 +54,7 @@ func colorize(new_color: Color):
 	self.set_meta("color", color)
 
 func get_config_name(version):
-	if version == 2:
+	if version >= 2:
 		return ConfigHandler.btn_config_names[index]
 	else:
 		return str(index)

--- a/InputBtn.gd.uid
+++ b/InputBtn.gd.uid
@@ -1,0 +1,1 @@
+uid://cgsscppx3t6ix

--- a/InputBtn.tscn
+++ b/InputBtn.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=5 format=3 uid="uid://3u1ers8tmwr8"]
 
-[ext_resource type="Script" path="res://InputBtn.gd" id="1_fkaf7"]
+[ext_resource type="Script" uid="uid://cgsscppx3t6ix" path="res://InputBtn.gd" id="1_fkaf7"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_oquh7"]
 size = Vector2(50, 50)

--- a/InputSources.gd.uid
+++ b/InputSources.gd.uid
@@ -1,0 +1,1 @@
+uid://np16qg1kynl1

--- a/InputStrum.tscn
+++ b/InputStrum.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://o6u0cs62c6md"]
 
-[ext_resource type="Script" path="res://InputBtn.gd" id="1_7v6oi"]
+[ext_resource type="Script" uid="uid://cgsscppx3t6ix" path="res://InputBtn.gd" id="1_7v6oi"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_omccp"]
 size = Vector2(125, 25)

--- a/Main.tscn
+++ b/Main.tscn
@@ -2,12 +2,12 @@
 
 [ext_resource type="PackedScene" uid="uid://3u1ers8tmwr8" path="res://InputBtn.tscn" id="1_rf5sa"]
 [ext_resource type="PackedScene" uid="uid://o6u0cs62c6md" path="res://InputStrum.tscn" id="2_lan1j"]
-[ext_resource type="Script" path="res://FPS.gd" id="4_i884g"]
+[ext_resource type="Script" uid="uid://c1lvyeh0nqgcw" path="res://FPS.gd" id="4_i884g"]
 [ext_resource type="Texture2D" uid="uid://hfjxlldsajma" path="res://ButtonHamburgerIcons/Idle.png" id="5_gohq5"]
 [ext_resource type="Texture2D" uid="uid://bb1lgvbgvt6ok" path="res://ButtonHamburgerIcons/Inbetween.png" id="6_vsqnb"]
 [ext_resource type="Texture2D" uid="uid://ds1xh0grlep6b" path="res://ButtonHamburgerIcons/Hover.png" id="7_gqgvc"]
 [ext_resource type="BitMap" uid="uid://cnj1o7mv0758k" path="res://ButtonHamburgerIcons/Click_mask.bmp" id="8_5hayx"]
-[ext_resource type="Script" path="res://HideableUI.gd" id="8_dtghk"]
+[ext_resource type="Script" uid="uid://djkjj2xp8gqn7" path="res://HideableUI.gd" id="8_dtghk"]
 
 [node name="Node2D" type="Node2D"]
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Axis calibration is done both at program startup, or whenever `` ` `` or `` ^ ``
 
 ## Controls
 
-- Click on top of the button to re-bind it to another key or button;
+- Click on top of the button to re-bind it to another key or button
 - Press `` ` `` or `` ^ `` to calibrate axes.
-- Press `backspace` to reset counters;
+- Press `backspace` to reset counters.
 
-- Press `escape` or click the "Hamburger Button" in the top left corner to open the Config Menu
+- Press `escape` or click the "Hamburger Button" in the top left corner to open the Config Menu.
 - Change a fret's color by left clicking it in the Config Menu.
 - Change Scroll Speed and Input bar width in the Config Menu. Scroll speed supports one digit of decimal precision.
 
@@ -45,13 +45,13 @@ All available Settings can be adjusted there.
 
 ### Settings For release 0.0.4 and prior
 
-(Note: It is recommended to *not* modify scroll_rate and width by directly editing the config file, and instead using the keybinds mentioned above.)
+#### (Note: It is recommended to *not* modify scroll_rate and width by directly editing the config file, and instead using the keybinds mentioned above.)
 
-- `scroll_rate`: Scrolling speed of the input bars, in pixels per second; the higher, the faster. Default: 400;
-- `width`: Sets the width in pixels of the input bars. Default: 50;
+- `scroll_rate`: Scrolling speed of the input bars, in pixels per second; the higher, the faster. (Default: 400).
+- `width`: Sets the width in pixels of the input bars. (Default: 50).
 - `green`, `red`, `yellow`, `blue`, `orange`, `up` and `down`: Sets the color of each element. Must be set as a RGB Hex value (i.e. `"#FF0000"` for red).
 
-(Note: On release 0.0.5+, these colors are called `fret_0`, `fret_1`, `fret_2`, `fret_3`, `fret_4`, `strum_up` and `strum_down.`)
+(Note: On release 0.0.5+, the colors are called `fret_0`, `fret_1`, `fret_2`, `fret_3`, `fret_4`, `strum_up` and `strum_down`.)
 
 If you cannot find the file, just open the input display and close it; the file is saved on application close.
 
@@ -59,7 +59,7 @@ If you cannot find the file, just open the input display and close it; the file 
 
 This is still WIP; here are some of the main TODO items (in no particular order):
 
-- Test with other guitars (currently tested with Santroller, Xplorer, Fender RB1 Xbox 360, Les Paul Xbox 360);
+- Test with other guitars (currently tested with Santroller, Xplorer, Fender RB1 Xbox 360, Les Paul Xbox 360)
 - Make FPS independent (requires rewrite)
 
 My time to work on this is relatively limited, but feel free to open issues and pull requests. Contributions are very welcome!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Yet another input display for Clone Hero / YARG **(WIP)**
 
-It's made using Godot 4.2.1.
+It's made using Godot 4.4.
 
 ![demo:](https://github.com/raphaelgoulart/ya_inputdisplay/blob/main/demo.gif)
 

--- a/Singleton.gd.uid
+++ b/Singleton.gd.uid
@@ -1,0 +1,1 @@
+uid://duhl1kbh0hxhn

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="ya_inputdisplay"
 run/main_scene="res://Main.tscn"
-config/features=PackedStringArray("4.2", "GL Compatibility")
+config/features=PackedStringArray("4.4", "GL Compatibility")
 run/max_fps=1000
 config/icon="res://Icon.svg"
 


### PR DESCRIPTION
This PR includes changes Godot made when updating the Godot version. As version 4.4 added `.uid` files for all GDScripts, If uploading the `uid`s from the repository owner's local project would be preffered, I can reopen this PR without the version bump.
This PR also contains some minor changes to the formatting of the Readme, most of which were mistakes of mine which I just recently spotted.
There is also a small "Fix" relating to Config versions. This one is mostly preparation for other changes which I am currently testing, and might PR at some point.